### PR TITLE
add swagpaths and swagtracks to REST API, include swagifacts in response

### DIFF
--- a/src/controller/SwagTrackController.php
+++ b/src/controller/SwagTrackController.php
@@ -16,7 +16,8 @@ class SwagTrackController extends Singleton {
 	public function init() {
 		register_taxonomy("swagtrack","swagpath",array(
 			"label"=>"Swagtracks",
-			"hierarchical"=>TRUE
+			"hierarchical"=>TRUE,
+			"show_in_rest"=>true
 		));
 
 		add_action("swagtrack_add_form_fields",array($this,"addFormFields"));


### PR DESCRIPTION
See `/wp-json/wp/v2/swagpath?_embed`

in addition to it's own attributes also will include swagifacts
```
"swagifacts": [
            {
                "title": "Getting Started With Sonic Pi",
                "slug": "getting-started-with-sonic-pi",
                "exportUrl": "http://172.28.128.4/wp-content/uploads/h5p/exports/getting-started-with-sonic-pi-1.h5p"
            },
            {
                "title": "Generating Sounds",
                "slug": "generating-sounds",
                "exportUrl": "http://172.28.128.4/wp-content/uploads/h5p/exports/generating-sounds-2.h5p"
            },
            {
                "title": "Making a Song",
                "slug": "making-a-song",
                "exportUrl": "http://172.28.128.4/wp-content/uploads/h5p/exports/making-a-song-3.h5p"
            }
        ],
```